### PR TITLE
Not include EOF into dataStore when open an existing file

### DIFF
--- a/godbf/dbfio.go
+++ b/godbf/dbfio.go
@@ -86,7 +86,12 @@ func createDbfTable(s []byte, fileEncoding string) (table *DbfTable, err error) 
 	dt.dataEntryStarted = true
 
 	// set DbfTable dataStore slice that will store the complete file in memory
-	dt.dataStore = s
+	lengthWithoutEOF := int(dt.lengthOfEachRecord)*int(dt.numberOfRecords) + int(dt.numberOfBytesInHeader)
+	if len(s) > lengthWithoutEOF && s[lengthWithoutEOF] == 0x1A {
+		dt.dataStore = s[:lengthWithoutEOF]
+	} else {
+		dt.dataStore = s
+	}
 
 	return dt, nil
 }


### PR DESCRIPTION
There is two reasons for that:

- On save file EOF always added
- On add new record EOF always ignored