### PR TITLE
Fix deletion marker initialization and ignore end of file marker while read file to dataStore.

### DIFF
--- a/godbf/dbfio.go
+++ b/godbf/dbfio.go
@@ -85,8 +85,9 @@ func createDbfTable(s []byte, fileEncoding string) (table *DbfTable, err error) 
 	// phase changing schema of dbase file is not allowed.
 	dt.dataEntryStarted = true
 
-	// set DbfTable dataStore slice that will store the complete file in memory
-	dt.dataStore = s
+	// set DbfTable dataStore slice that will store the complete file in memory,
+	// and remove the end of file marker (0x1A)
+	dt.dataStore = s[:len(s)-1]
 
 	return dt, nil
 }

--- a/godbf/dbftable.go
+++ b/godbf/dbftable.go
@@ -328,6 +328,10 @@ func (dt *DbfTable) AddNewRecord() (newRecordNumber int) {
 	}
 
 	newRecord := make([]byte, dt.lengthOfEachRecord)
+
+	// set deletion marker to blank
+	newRecord[0] = blank 
+
 	dt.dataStore = appendSlice(dt.dataStore, newRecord)
 
 	// since row numbers are "0" based first we set newRecordNumber


### PR DESCRIPTION
Fix deletion marker initialization and ignore end of file marker while read file to dataStore. so other DBF viewer can read the file after edit by `go-dbf`