### PR TITLE
Change trim spaces logic for a field value

### DIFF
--- a/godbf/dbftable.go
+++ b/godbf/dbftable.go
@@ -448,7 +448,7 @@ func (dt *DbfTable) FieldValue(row int, fieldIndex int) (value string) {
 	s := dt.decoder.ConvertString(string(temp))
 	//fmt.Printf("utf-8 value:[%#v] original value:[%#v]\n", s, string(temp))
 
-	value = strings.TrimSpace(s)
+	value = strings.TrimRight(s, " ")
 
 	//fmt.Printf("raw value:[%#v]\n", dt.dataStore[(offset + recordOffset):((offset + recordOffset) + int(dt.Fields[fieldIndex].fixedFieldLength))])
 	//fmt.Printf("utf-8 value:[%#v]\n", []byte(s))


### PR DESCRIPTION
In some DBF files records separated into few lines. It happens when some field in record more than 254 characters.

And when you will try to combine these lines to one record you need that original spaces to be kept. It is not possible for the right spaces,  but possible for left spaces.

LibreOffice Calc does the same. It keeps left spaces because left spaces it is the decision of a user who built a file but trims right spaces