### PR TITLE
active record must have a space in deletion flag

### DIFF
--- a/godbf/dbftable.go
+++ b/godbf/dbftable.go
@@ -328,6 +328,10 @@ func (dt *DbfTable) AddNewRecord() (newRecordNumber int) {
 	}
 
 	newRecord := make([]byte, dt.lengthOfEachRecord)
+	// each record begins with a 1-byte "deletion" flag. If record is active the byte's value is a space (0x20)
+	if dt.lengthOfEachRecord > 0 {
+		newRecord[0] = 0x20
+	}
 	dt.dataStore = appendSlice(dt.dataStore, newRecord)
 
 	// since row numbers are "0" based first we set newRecordNumber


### PR DESCRIPTION
According by [dbf file format](https://www.dbase.com/Knowledgebase/INT/db7_file_fmt.htm), chapter "Table Records": Data records are preceded by one byte, that is, a space (0x20) if the record is not deleted, an asterisk (0x2A) if the record is deleted