### PR TITLE
Added function SetRowIsDeleted

### DIFF
--- a/godbf/table.go
+++ b/godbf/table.go
@@ -555,6 +555,21 @@ func (dt *DbfTable) RowIsDeleted(row int) bool {
 	return dt.dataStore[offset:(offset + 1)][recordDeletionFlagIndex] == recordIsDeleted
 }
 
+// SetRowIsDeleted sets a row as deleted
+func (dt *DbfTable) SetRowIsDeleted(row int) (err error) {
+	offset := int(dt.numberOfBytesInHeader)
+	lengthOfRecord := int(dt.lengthOfEachRecord)
+	offset = offset + (row * lengthOfRecord)
+	dt.dataStore[offset:(offset + 1)][recordDeletionFlagIndex] = recordIsDeleted
+
+	if !dt.RowIsDeleted(row) {
+		err = errors.New("could not mark row as deleted")
+		return
+	}
+
+	return
+}
+
 // GetRowAsSlice return the record values for the row specified as a string slice
 func (dt *DbfTable) GetRowAsSlice(row int) []string {
 


### PR DESCRIPTION
Hey Lindsay,

thanks a lot for creating this library.
I am using it for a project where we use old DBF files as a database for a web service.

The function, I added, marks the defined row as deleted. I tested it successfully locally by saving the table as a new file, using SaveToFile() 
I checked it using a DBFViewer application and by exporting it to LibreOffices Calc. The marked row was not part of the file anymore.

Maybe it is useful as an addition to your code.